### PR TITLE
Update PyRuler code.py to support Linux keycodes

### DIFF
--- a/boards/pyruler/4.x/code.py
+++ b/boards/pyruler/4.x/code.py
@@ -7,9 +7,12 @@ import touchio
 # Set this to True to turn the touchpads into a keyboard
 ENABLE_KEYBOARD = False
 
-# Set your computer type to True, if Linux set both to False
-WINDOWS = True
-MAC = False
+WINDOWS = "W"
+MAC = "M"
+LINUX = "L"  # and Chrome OS
+
+# Set your computer type to one of the above
+OS = WINDOWS
 
 # Used if we do HID output, see below
 if ENABLE_KEYBOARD:
@@ -79,13 +82,12 @@ while True:
         leds[i].value = c
     if caps[0]:
         if ENABLE_KEYBOARD:
-            if WINDOWS:
+            if OS == WINDOWS:
                 type_alt_code(234)
-            elif MAC:
+            elif OS == MAC:
                 kbd.send(Keycode.ALT, Keycode.Z)
-            else:
-                kbd.press(Keycode.CONTROL)
-                kbd.press(Keycode.SHIFT)
+            elif OS == LINUX:
+                kbd.press(Keycode.CONTROL, Keycode.SHIFT)
                 kbd.press(Keycode.U)
                 kbd.release_all()
                 kbd.send(Keycode.TWO)
@@ -95,13 +97,12 @@ while True:
                 kbd.send(Keycode.ENTER)
     if caps[1]:
         if ENABLE_KEYBOARD:
-            if WINDOWS:
+            if OS == WINDOWS:
                 type_alt_code(230)
-            elif MAC:
+            elif OS == MAC:
                 kbd.send(Keycode.ALT, Keycode.M)
-            else:
-                kbd.press(Keycode.CONTROL)
-                kbd.press(Keycode.SHIFT)
+            elif OS == LINUX:
+                kbd.press(Keycode.CONTROL, Keycode.SHIFT)
                 kbd.press(Keycode.U)
                 kbd.release_all()
                 kbd.send(Keycode.ZERO)
@@ -111,13 +112,12 @@ while True:
                 kbd.send(Keycode.ENTER)
     if caps[2]:
         if ENABLE_KEYBOARD:
-            if WINDOWS:
+            if OS == WINDOWS:
                 type_alt_code(227)
-            elif MAC:
+            elif OS == MAC:
                 kbd.send(Keycode.ALT, Keycode.P)
-            else:
-                kbd.press(Keycode.CONTROL)
-                kbd.press(Keycode.SHIFT)
+            elif OS == LINUX:
+                kbd.press(Keycode.CONTROL, Keycode.SHIFT)
                 kbd.press(Keycode.U)
                 kbd.release_all()
                 kbd.send(Keycode.ZERO)
@@ -129,4 +129,3 @@ while True:
         if ENABLE_KEYBOARD:
             layout.write('https://www.digikey.com/python\n')
     time.sleep(0.1)
-    

--- a/boards/pyruler/4.x/code.py
+++ b/boards/pyruler/4.x/code.py
@@ -7,8 +7,9 @@ import touchio
 # Set this to True to turn the touchpads into a keyboard
 ENABLE_KEYBOARD = False
 
-# Set this to true if you're on windows, false if you're on mac
-WINDOWS_COMPUTER = True
+# Set your computer type to True, if Linux set both to False
+WINDOWS = True
+MAC = False
 
 # Used if we do HID output, see below
 if ENABLE_KEYBOARD:
@@ -78,23 +79,54 @@ while True:
         leds[i].value = c
     if caps[0]:
         if ENABLE_KEYBOARD:
-            if WINDOWS_COMPUTER:
+            if WINDOWS:
                 type_alt_code(234)
-            else:
+            elif MAC:
                 kbd.send(Keycode.ALT, Keycode.Z)
+            else:
+                kbd.press(Keycode.CONTROL)
+                kbd.press(Keycode.SHIFT)
+                kbd.press(Keycode.U)
+                kbd.release_all()
+                kbd.send(Keycode.TWO)
+                kbd.send(Keycode.ONE)
+                kbd.send(Keycode.TWO)
+                kbd.send(Keycode.SIX)
+                kbd.send(Keycode.ENTER)
     if caps[1]:
         if ENABLE_KEYBOARD:
-            if WINDOWS_COMPUTER:
+            if WINDOWS:
                 type_alt_code(230)
-            else:
+            elif MAC:
                 kbd.send(Keycode.ALT, Keycode.M)
+            else:
+                kbd.press(Keycode.CONTROL)
+                kbd.press(Keycode.SHIFT)
+                kbd.press(Keycode.U)
+                kbd.release_all()
+                kbd.send(Keycode.ZERO)
+                kbd.send(Keycode.THREE)
+                kbd.send(Keycode.B)
+                kbd.send(Keycode.C)
+                kbd.send(Keycode.ENTER)
     if caps[2]:
         if ENABLE_KEYBOARD:
-            if WINDOWS_COMPUTER:
+            if WINDOWS:
                 type_alt_code(227)
-            else:
+            elif MAC:
                 kbd.send(Keycode.ALT, Keycode.P)
+            else:
+                kbd.press(Keycode.CONTROL)
+                kbd.press(Keycode.SHIFT)
+                kbd.press(Keycode.U)
+                kbd.release_all()
+                kbd.send(Keycode.ZERO)
+                kbd.send(Keycode.THREE)
+                kbd.send(Keycode.C)
+                kbd.send(Keycode.ZERO)
+                kbd.send(Keycode.ENTER)
     if caps[3]:
         if ENABLE_KEYBOARD:
             layout.write('https://www.digikey.com/python\n')
     time.sleep(0.1)
+    


### PR DESCRIPTION
Update PyRuler code.py to support keycodes for Linux and Chrome OS computers. It's not as elegant as your type_alt_code function, but it works. If I find time I can probably come up with a function to accept the Unicode code and send the keystrokes like you did with the windows alt codes.